### PR TITLE
fix default value of msgctxt field

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -164,7 +164,7 @@ PO.parse = function (data) {
 
 PO.Item = function () {
     this.msgid = '';
-    this.msgctxt = '';
+    this.msgctxt = null;
     this.references = [];
     this.msgid_plural = null;
     this.msgstr = [];

--- a/test/write.js
+++ b/test/write.js
@@ -38,10 +38,28 @@ describe('Write', function () {
         assertHasLine(str, "msgstr \"Source\"");
     });
 
-    it('write msgctxt', function () {
-        var input = fs.readFileSync(__dirname + '/fixtures/big.po', 'utf8');
-        var po = PO.parse(input);
-        var str = po.toString();
-        assertHasLine(str, 'msgctxt "folder action"');
+    describe('msgctxt', function () {
+        it('should write context field to file', function () {
+            var input = fs.readFileSync(__dirname + '/fixtures/big.po', 'utf8');
+            var po = PO.parse(input);
+            var str = po.toString();
+            assertHasLine(str, 'msgctxt "folder action"');
+        });
+
+        it('should ignore omitted context field', function () {
+            var po = new PO();
+            var item = new PO.Item();
+            po.items.push(item);
+            assert.ok(po.toString().indexOf('msgctxt') < 0);
+        });
+
+        it('should write empty context field', function () {
+            var po = new PO();
+            var item = new PO.Item();
+
+            item.msgctxt = '';
+            po.items.push(item);
+            assert.ok(po.toString().indexOf('msgctxt') >= 0);
+        });
     });
 });


### PR DESCRIPTION
I added a few more edge-cases to the tests for the new msgctxt field and
revealed a bug during that. The default value has been set to empty
string, but should have been null, since the spec says, this field is
optional.
