### PR TITLE
add support for multiline string in headers

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -74,7 +74,18 @@ PO.parse = function (data) {
         'Plural-Forms': '',
     };
 
-    headers.split(/\n/).forEach(function (header) {
+    headers.split(/\n/).reduce(function (acc, line) {
+        if (acc.merge) {
+            //join lines, remove last resp. first "
+            line = acc.pop().slice(0, -1) + line.slice(1);
+            delete acc.merge;
+        }
+        if (/^".*"$/.test(line) && !/^".*\\n"$/.test(line)) {
+            acc.merge = true;
+        }
+        acc.push(line);
+        return acc;
+    }, []).forEach(function (header) {
         if (header.match(/^#/)) {
             po.comments.push(header.replace(/^#\s*/, ''));
         }

--- a/test/fixtures/multi-line.po
+++ b/test/fixtures/multi-line.po
@@ -1,6 +1,8 @@
 # French translation of Link (6.x-2.9)
 # Copyright (c) 2011 by the French translation team
 #
+## Plural-Forms by polish translation team to demonstrate multi-line ##
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Link (6.x-2.9)\n"
@@ -10,7 +12,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 "
+"|| n%100>=20) ? 1 : 2;\n"
 "Last-Translator: Ruben Vermeersch <ruben@rocketeer.be>\n"
 "Language: fr\n"
 "X-Generator: Poedit 1.6.2\n"

--- a/test/parse.js
+++ b/test/parse.js
@@ -23,6 +23,14 @@ describe('Parse', function () {
         assert.equal(item.msgstr, "Les ébauches de jetons suivantes peuvent être utilisées à la fois dans les chemins et dans les titres. Lorsqu'elles sont utilisées dans un chemin ou un titre, elles seront remplacées par les valeurs appropriées.");
     });
 
+    it('Handles multi-line headers', function () {
+        var po = PO.parse(fs.readFileSync(__dirname + '/fixtures/multi-line.po', 'utf8'));
+        assert.notEqual(po, null);
+        assert.equal(po.items.length, 1);
+
+        assert.equal(po.headers['Plural-Forms'], 'nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;');
+    });
+
     it('Handles translator comments', function () {
         var po = PO.parse(fs.readFileSync(__dirname + '/fixtures/comment.po', 'utf8'));
         assert.notEqual(po, null);


### PR DESCRIPTION
Some languages (such as Polish, Russian or Romanian) do have more
complicated plural forms. Those are still expressible by a more
complicated mathematical expression. However, the msgmerge tool of
gettext will in these cases write multiline header fields. When parsing
such files with this lib, the headers get screwed up, so this patch
provides an example (from a pl_PL po file) and fixes this by joining the
lines in the header, before doing the actual parsing.
