### PR TITLE
Fix commented obsolete strings

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -101,14 +101,18 @@ PO.parse = function (data) {
     var item = new PO.Item(),
         context = null,
         plural = 0,
-        obsolete = false;
+        obsoleteCount = 0,
+        noCommentLineCount = 0;
 
     function finish() {
         if (item.msgid.length > 0) {
+            if (obsoleteCount >= noCommentLineCount) {
+                item.obsolete = true;
+            }
+            obsoleteCount = 0;
+            noCommentLineCount = 0;
             po.items.push(item);
             item = new PO.Item();
-            item.obsolete = obsolete;
-            obsolete = false;
         }
     }
 
@@ -122,13 +126,15 @@ PO.parse = function (data) {
 
     while (lines.length > 0) {
         var line = trim(lines.shift()),
+            lineObsolete = false,
             add = false;
 
         if (line.match(/^#\~/)) { // Obsolete item
-            obsolete = true;
+            //only remove the obsolte comment mark, here
+            //might be, this is a new item, so
+            //only remember, this line is marked obsolete, count after line is parsed
             line = trim(line.substring(2));
-        } else {
-            obsolete = false;
+            lineObsolete = true;
         }
 
         if (line.match(/^#:/)) { // Reference
@@ -153,24 +159,29 @@ PO.parse = function (data) {
         else if (line.match(/^msgid_plural/)) { // Plural form
             item.msgid_plural = extract(line);
             context = 'msgid_plural';
+            noCommentLineCount++;
         }
         else if (line.match(/^msgid/)) { // Original
             finish();
             item.msgid = extract(line);
             context = 'msgid';
+            noCommentLineCount++;
         }
         else if (line.match(/^msgstr/)) { // Translation
             var m = line.match(/^msgstr\[(\d+)\]/);
             plural = m && m[1] ? parseInt(m[1]) : 0;
             item.msgstr[plural] = extract(line);
             context = 'msgstr';
+            noCommentLineCount++;
         }
         else if (line.match(/^msgctxt/)) { // Context
             finish();
             item.msgctxt = extract(line);
+            noCommentLineCount++;
         }
         else { // Probably multiline string or blank
             if (line.length > 0) {
+                noCommentLineCount++;
                 if (context === 'msgstr') {
                     item.msgstr[plural] += extract(line);
                 }
@@ -181,6 +192,10 @@ PO.parse = function (data) {
                     item.msgid_plural += extract(line);
                 }
             }
+        }
+        if (lineObsolete) {
+            //count obsolete lines for this item
+            obsoleteCount++;
         }
     }
     finish();
@@ -245,27 +260,24 @@ PO.Item.prototype.toString = function () {
     if (flags.length > 0) {
         lines.push('#, ' + flags.join(","));
     }
+    var mkObsolete = this.obsolete ? '#~ ' : '';
 
     ['msgctxt', 'msgid', 'msgid_plural', 'msgstr'].forEach(function (keyword) {
         var text = that[keyword];
         if (text != null) {
             if (isArray(text) && text.length > 1) {
                 text.forEach(function (t, i) {
-                    lines = lines.concat(_process(keyword, t, i));
+                    lines = lines.concat(mkObsolete + _process(keyword, t, i));
                 });
             }
             else {
                 text = isArray(text) ? text.join() : text;
-                lines = lines.concat(_process(keyword, text));
+                lines = lines.concat(mkObsolete + _process(keyword, text));
             }
         }
     });
 
-    if (this.obsolete) {
-        return "#~ " + lines.join("\n#~ ");
-    } else {
-        return lines.join("\n");
-    }
+    return lines.join("\n");
 };
 
 module.exports = PO;

--- a/test/fixtures/commented.po
+++ b/test/fixtures/commented.po
@@ -21,3 +21,13 @@ msgstr "{{dataLoader.data.length}} resultaten"
 
 #~ msgid "Add order"
 #~ msgstr "Order toevoegen"
+
+#~ # commented obsolete item
+#~ #, fuzzy
+#~ msgid "Commented item"
+#~ msgstr "not sure"
+
+# commented obsolete item
+#, fuzzy
+#~ msgid "Second commented item"
+#~ msgstr "also not sure"

--- a/test/parse.js
+++ b/test/parse.js
@@ -96,7 +96,7 @@ describe('Parse', function () {
     it('Handles obsolete items', function () {
         var po = PO.parse(fs.readFileSync(__dirname + '/fixtures/commented.po', 'utf8'));
 
-        assert.equal(po.items.length, 2);
+        assert.equal(po.items.length, 4);
         var item = po.items[0];
         assert.equal(item.obsolete, false);
         assert.equal(item.msgid, '{{dataLoader.data.length}} results');
@@ -106,6 +106,16 @@ describe('Parse', function () {
         assert.equal(item.obsolete, true);
         assert.equal(item.msgid, 'Add order');
         assert.equal(item.msgstr, 'Order toevoegen');
+
+        item = po.items[2];
+        assert.equal(item.obsolete, true);
+        assert.equal(item.msgid, 'Commented item');
+        assert.equal(item.msgstr, 'not sure');
+
+        item = po.items[3];
+        assert.equal(item.obsolete, true);
+        assert.equal(item.msgid, 'Second commented item');
+        assert.equal(item.msgstr, 'also not sure');
     });
 
     describe('C-Strings', function () {

--- a/test/write.js
+++ b/test/write.js
@@ -61,6 +61,22 @@ describe('Write', function () {
         assertHasLine(str, '#~ msgstr "Order toevoegen"');
     });
 
+    it('write obsolete items with comment', function () {
+        var input = fs.readFileSync(__dirname + '/fixtures/commented.po', 'utf8');
+        var po = PO.parse(input);
+        var str = po.toString();
+
+        //this is what msgcat tool of gettext does: don't print #~ for comments
+        assertHasLine(str, '# commented obsolete item');
+        assertHasLine(str, '#, fuzzy');
+
+        //items made obsolete by commenting every keyword with #~
+        assertHasLine(str, '#~ msgid "Commented item"');
+        assertHasLine(str, '#~ msgstr "not sure"');
+        assertHasLine(str, '#~ msgid "Second commented item"');
+        assertHasLine(str, '#~ msgstr "also not sure"');
+    });
+
     describe('C-Strings', function () {
         it('should escape "', function () {
             var item = new PO.Item();


### PR DESCRIPTION
the current implementation of items marked obsolete did not allow "plain"
comments for these items. However, this is perfectly fine according to
the original gettext tools. When writing a po file, comments for obsolete
items don't contain the '#~ ' mark (tested using msgcat), so this is now
also aligned with the behaviour of the original gettext tools.

For all these cases I added examples in the po files, that failed with the
current implementation and work fine after these changes.
