### PR TITLE
handle empty comments correctly

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -146,9 +146,9 @@ PO.parse = function (data) {
             for (var i = 0; i < flags.length; i++) {
                 item.flags[flags[i]] = true;
             }
-        } else if (line.match(/^#\s+/)) { // Translator comment
+        } else if (line.match(/^#($|\s+)/)) { // Translator comment
             finish();
-            item.comments.push(trim(line.replace(/^#\s+/, '')));
+            item.comments.push(trim(line.replace(/^#($|\s+)/, '')));
         } else if (line.match(/^#\./)) { // Extracted comment
             finish();
             item.extractedComments.push(trim(line.replace(/^#\./, '')));

--- a/test/fixtures/comment.po
+++ b/test/fixtures/comment.po
@@ -19,3 +19,11 @@ msgstr ""
 #. Extracted comment
 msgid "Title, as plain text"
 msgstr "Attribut title, en tant que texte brut"
+
+#
+#.
+#:
+#, fuzzy
+msgid "Empty comment"
+msgstr "Empty"
+

--- a/test/parse.js
+++ b/test/parse.js
@@ -31,10 +31,24 @@ describe('Parse', function () {
         assert.equal(po.headers['Plural-Forms'], 'nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;');
     });
 
+    it('Handle empty comments', function (done) {
+        PO.load(__dirname + '/fixtures/comment.po', function (err, po) {
+            assert.equal(err, null);
+
+            var item = po.items[1];
+            assert.equal(item.msgid, 'Empty comment');
+            assert.equal(item.msgstr, 'Empty');
+            assert.deepEqual(item.comments, ['']);
+            assert.deepEqual(item.extractedComments, ['']);
+            assert.deepEqual(item.references, ['']);
+            done();
+        });
+    });
+
     it('Handles translator comments', function () {
         var po = PO.parse(fs.readFileSync(__dirname + '/fixtures/comment.po', 'utf8'));
         assert.notEqual(po, null);
-        assert.equal(po.items.length, 1);
+        assert.equal(po.items.length, 2);
 
         var item = po.items[0];
         assert.equal(item.msgid, 'Title, as plain text');
@@ -45,7 +59,7 @@ describe('Parse', function () {
     it('Handles extracted comments', function () {
         var po = PO.parse(fs.readFileSync(__dirname + '/fixtures/comment.po', 'utf8'));
         assert.notEqual(po, null);
-        assert.equal(po.items.length, 1);
+        assert.equal(po.items.length, 2);
 
         var item = po.items[0];
         assert.equal(item.msgid, 'Title, as plain text');


### PR DESCRIPTION
since the lines in the parser have all newline characters removed, \s+ will
not match empty comments.

Added an example that makes other tests fail without this patch.
