### PR TITLE
restore previous behaviour with \n in strings

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -261,7 +261,8 @@ PO.Item.prototype.toString = function () {
                 });
             } else {
                 text = isArray(text) ? text.join() : text;
-                lines = lines.concat(mkObsolete + _process(keyword, text));
+                var processed = _process(keyword, text);
+                lines = lines.concat(mkObsolete + processed.join('\n' + mkObsolete));
             }
         }
     });

--- a/test/write.js
+++ b/test/write.js
@@ -92,6 +92,15 @@ describe('Write', function () {
             assertHasLine(item.toString(), 'msgid "\\\\ should be written escaped"');
         });
 
+        it('should escape \\n', function () {
+            var item = new PO.Item();
+
+            item.msgid = '\n should be written escaped';
+            assertHasLine(item.toString(), 'msgid ""');
+            assertHasLine(item.toString(), '""');
+            assertHasLine(item.toString(), '" should be written escaped"');
+        });
+
         it('should write identical file after parsing a file', function () {
             var input = fs.readFileSync(__dirname + '/fixtures/c-strings.po', 'utf8');
             var po = PO.parse(input);


### PR DESCRIPTION
An incompatible change (that actually breaks po parsing after writing) had
been introduced with commit e164fcfe9d6f28cd3d452f4de274a41663160cef. If
_process returned an array (which is the case for strings containing \n
character), array.toString will return a comma separated list, which is not
valid po syntax. Added a test to restore the behaviour from before the
e164fcfe9d6f28cd3d452f4de274a41663160cef.
## 

Seems there is still some more to be fixed ;) I found out, that I introduced a bug, that really should be fixed. However, while I was at it, I also started to thinking about #2. At least for the newline case, I verified, that pofile doesn't behave like gettext tools do. I will add some tests for these cases, that will work with mikejholly/node-po#3 merged.
