### PR TITLE
add tests to better document reference comments

### DIFF
--- a/test/fixtures/reference.po
+++ b/test/fixtures/reference.po
@@ -24,3 +24,7 @@ msgstr "Attribut title, en tant que texte brut"
 #: b
 msgid "X"
 msgstr "Y"
+
+#: standard input:12 standard input:17
+msgid "Z"
+msgstr "ZZ"

--- a/test/parse.js
+++ b/test/parse.js
@@ -67,21 +67,32 @@ describe('Parse', function () {
         assert.deepEqual(item.extractedComments, ['Extracted comment']);
     });
 
-    it('Handles string references', function () {
+    describe('Handles string references', function () {
         var po = PO.parse(fs.readFileSync(__dirname + '/fixtures/reference.po', 'utf8'));
         assert.notEqual(po, null);
-        assert.equal(po.items.length, 2);
+        assert.equal(po.items.length, 3);
 
-        var item = po.items[0];
-        assert.equal(item.msgid, 'Title, as plain text');
-        assert.equal(item.msgstr, 'Attribut title, en tant que texte brut');
-        assert.deepEqual(item.comments, ['Comment']);
-        assert.deepEqual(item.references, ['.tmp/crm/controllers/map.js']);
+        it('in simple cases', function () {
+            var item = po.items[0];
+            assert.equal(item.msgid, 'Title, as plain text');
+            assert.equal(item.msgstr, 'Attribut title, en tant que texte brut');
+            assert.deepEqual(item.comments, ['Comment']);
+            assert.deepEqual(item.references, ['.tmp/crm/controllers/map.js']);
+        });
 
-        item = po.items[1];
-        assert.equal(item.msgid, 'X');
-        assert.equal(item.msgstr, 'Y');
-        assert.deepEqual(item.references, ['a', 'b']);
+        it('with two different references', function () {
+            var item = po.items[1];
+            assert.equal(item.msgid, 'X');
+            assert.equal(item.msgstr, 'Y');
+            assert.deepEqual(item.references, ['a', 'b']);
+        });
+
+        it('and does not process reference items', function () {
+            var item = po.items[2];
+            assert.equal(item.msgid, 'Z');
+            assert.equal(item.msgstr, 'ZZ');
+            assert.deepEqual(item.references, ['standard input:12 standard input:17']);
+        });
     });
 
     it('Parses flags', function () {


### PR DESCRIPTION
pofile does not process reference comments in any way, since the format of
references is not exactly specified. This test specifies, what users of
pofile can expect the library to do.

This is just a suggestion that can be used as a base for discussion on how exactly to solve issue #13.
