### PR TITLE
Sort PO.Item comments

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -277,21 +277,21 @@ PO.Item.prototype.toString = function () {
     // https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html
     // says order is translator-comments, extracted-comments, references, flags
 
-    this.comments.forEach(function (c) {
+    this.comments.sort().forEach(function (c) {
         lines.push('# ' + c);
     });
 
-    this.extractedComments.forEach(function (c) {
+    this.extractedComments.sort().forEach(function (c) {
         lines.push('#. ' + c);
     });
 
-    this.references.forEach(function (ref) {
+    this.references.sort().forEach(function (ref) {
         lines.push('#: ' + ref);
     });
 
     var flags = Object.keys(this.flags);
     if (flags.length > 0) {
-        lines.push('#, ' + flags.join(','));
+        lines.push('#, ' + flags.sort().join(','));
     }
     var mkObsolete = this.obsolete ? '#~ ' : '';
 


### PR DESCRIPTION
The entries within each comment group get sorted alphabetically in `toString` output.
Flags also get sorted.

Resolves rubenv/angular-gettext#135
