### PR TITLE
fix issue #16

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -64,7 +64,12 @@ PO.parse = function (data) {
     data = data.replace(/\r\n/g, '\n');
     var po = new PO();
     var sections = data.split(/\n\n/);
-    var headers = sections.shift();
+    var headers = [sections.shift()];
+    //everything until the first 'msgid ""' is considered header
+    while (headers[headers.length - 1].indexOf('msgid ""') < 0) {
+        headers.push(sections.shift());
+    }
+    headers = headers.join('\n');
     var lines = sections.join('\n').split(/\n/);
 
     po.headers = {

--- a/test/fixtures/big.po
+++ b/test/fixtures/big.po
@@ -1,4 +1,5 @@
 # French translation of Link (6.x-2.9)
+
 # Copyright (c) 2011 by the French translation team
 #
 msgid ""


### PR DESCRIPTION
add a blank line in the comments of the headers of the big.po file. This
breaks parsing the headers. msgcat of gettext tools just ignores empty
lines until a header is found and treats everything above as header
comment.

The change to the library itself fixes the tests again, after the blank
linke broke 3.