### PR TITLE
singular form msgstr used together with msgid plural

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -275,6 +275,11 @@ PO.Item.prototype.toString = function () {
         });
         return string;
     };
+    
+    // generate msgstr for msgid_plural properly
+    if (self.msgid_plural !== null) {
+        self.msgstr = ['', ''];
+    }
 
     var _process = function (keyword, text, i) {
         var lines = [];


### PR DESCRIPTION
For plural form this tool generates this:
```msgid "%d Comment"
msgid_plural "%d Comments"
msgstr ""```

poedit and probably other editor are going to throw an error because when we use the plural form we should use multiple `msgstr`

My change will generate this result:
```msgid "%d Comment"
msgid_plural "%d Comments"
msgstr[0] ""
msgstr[1] ""```