### PR TITLE
Write proper plural msgstr[0]

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -5,7 +5,7 @@ module.exports = (grunt) ->
     @loadNpmTasks('grunt-contrib-jshint')
     @loadNpmTasks('grunt-contrib-uglify')
     @loadNpmTasks('grunt-contrib-watch')
-    @loadNpmTasks('grunt-jscs-checker')
+    @loadNpmTasks('grunt-jscs')
     @loadNpmTasks('grunt-mocha-cli')
 
     @initConfig
@@ -42,8 +42,6 @@ module.exports = (grunt) ->
             dist:
                 files:
                     'dist/pofile.js': ['lib/po.js']
-                options:
-                    alias: 'lib/po.js:pofile'
 
         uglify:
             dist:

--- a/lib/po.js
+++ b/lib/po.js
@@ -1,5 +1,4 @@
 var fs = require('fs');
-var isArray = require('lodash.isarray');
 
 function trim(string) {
     return string.replace(/^\s+|\s+$/g, '');
@@ -317,12 +316,12 @@ PO.Item.prototype.toString = function () {
     ['msgctxt', 'msgid', 'msgid_plural', 'msgstr'].forEach(function (keyword) {
         var text = self[keyword];
         if (text != null) {
-            if (isArray(text) && text.length > 1) {
+            if (Array.isArray(text) && text.length > 1) {
                 text.forEach(function (t, i) {
                     lines = lines.concat(mkObsolete + _process(keyword, t, i));
                 });
             } else {
-                text = isArray(text) ? text.join() : text;
+                text = Array.isArray(text) ? text.join() : text;
                 var processed = _process(keyword, text);
                 //handle \n in single-line texts (can not be handled in _escape)
                 for (var i = 1; i < processed.length - 1; i++) {

--- a/lib/po.js
+++ b/lib/po.js
@@ -321,8 +321,11 @@ PO.Item.prototype.toString = function () {
                     lines = lines.concat(mkObsolete + _process(keyword, t, i));
                 });
             } else {
+                var index = (self.msgid_plural && Array.isArray(text)) ?
+                    0 :
+                    undefined;
                 text = Array.isArray(text) ? text.join() : text;
-                var processed = _process(keyword, text);
+                var processed = _process(keyword, text, index);
                 //handle \n in single-line texts (can not be handled in _escape)
                 for (var i = 1; i < processed.length - 1; i++) {
                     processed[i] = processed[i].slice(0, -1) + '\\n"';

--- a/package.json
+++ b/package.json
@@ -46,7 +46,5 @@
     "grunt-jscs": "~3.0.1",
     "grunt-mocha-cli": "~3.0.0"
   },
-  "dependencies": {
-    "lodash.isarray": "~2.4.1"
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -35,16 +35,16 @@
     "test": "test"
   },
   "devDependencies": {
-    "browserify": "~3.11.1",
-    "grunt": "~0.4.2",
-    "grunt-browserify": "~1.3.0",
-    "grunt-bump": "0.0.13",
-    "grunt-contrib-clean": "~0.5.0",
-    "grunt-contrib-jshint": "~0.7.2",
-    "grunt-contrib-uglify": "~0.2.7",
-    "grunt-contrib-watch": "~0.5.3",
-    "grunt-jscs-checker": "^0.5.1",
-    "grunt-mocha-cli": "~1.4.0"
+    "browserify": "~14.0.0",
+    "grunt": "~1.0.1",
+    "grunt-browserify": "~5.0.0",
+    "grunt-bump": "0.8.0",
+    "grunt-contrib-clean": "~1.0.0",
+    "grunt-contrib-jshint": "~1.1.0",
+    "grunt-contrib-uglify": "~2.1.0",
+    "grunt-contrib-watch": "~1.0.0",
+    "grunt-jscs": "~3.0.1",
+    "grunt-mocha-cli": "~3.0.0"
   },
   "dependencies": {
     "lodash.isarray": "~2.4.1"

--- a/test/fixtures/plural.po
+++ b/test/fixtures/plural.po
@@ -1,0 +1,32 @@
+# French translation of Link (6.x-2.9)
+# Copyright (c) 2011 by the French translation team
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Link (6.x-2.9)\n"
+"POT-Creation-Date: 2011-12-31 23:39+0000\n"
+"PO-Revision-Date: 2013-12-17 14:59+0100\n"
+"Language-Team: French\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Last-Translator: Ruben Vermeersch <ruben@rocketeer.be>\n"
+"Language: fr\n"
+"X-Generator: Poedit 1.6.2\n"
+
+# correct plurals, with translation
+msgid "1 source"
+msgid_plural "{{$count}} sources"
+msgstr[0] "1 source"
+msgstr[1] "{{$count}} sources"
+
+# correct plurals, with no translation
+msgid "1 destination"
+msgid_plural "{{$count}} destinations"
+msgstr[0] ""
+
+# incorrect plurals, with no translation
+msgid "1 mistake"
+msgid_plural "{{$count}} mistakes"
+msgstr ""

--- a/test/write.js
+++ b/test/write.js
@@ -16,6 +16,21 @@ function assertHasLine(str, line) {
     assert(found, 'Could not find line: ' + line);
 }
 
+function assertHasContiguousLines(str, assertedLines) {
+    var assertedLinesJoined = assertedLines.join('\n');
+
+    var trimmedStr = str
+        .split('\n')
+        .map(function (line) {
+            return line.trim();
+        })
+        .join('\n');
+
+    var found = trimmedStr.indexOf(assertedLinesJoined) !== -1;
+
+    assert(found, 'Could not find lines: \n' + assertedLinesJoined);
+}
+
 function assertDoesntHaveLine(str, line) {
     var lines = str.split('\n');
     var found = false;
@@ -101,6 +116,38 @@ describe('Write', function () {
         assertHasLine(str, '#~ msgstr "not sure"');
         assertHasLine(str, '#~ msgid "Second commented item"');
         assertHasLine(str, '#~ msgstr "also not sure"');
+    });
+
+    describe('plurals', function () {
+        it('should write multiple msgstrs', function () {
+            var input = fs.readFileSync(__dirname + '/fixtures/plural.po', 'utf8');
+            var po = PO.parse(input);
+            var str = po.toString();
+            assertHasContiguousLines(str, [
+                'msgstr[0] "1 source"',
+                'msgstr[1] "{{$count}} sources"'
+            ]);
+        });
+
+        it('should write msgstr[0] when there is no translation', function () {
+            var input = fs.readFileSync(__dirname + '/fixtures/plural.po', 'utf8');
+            var po = PO.parse(input);
+            var str = po.toString();
+            assertHasContiguousLines(str, [
+                'msgid_plural "{{$count}} destinations"',
+                'msgstr[0] ""'
+            ]);
+        });
+
+        it('should write msgstr[0] when there is no translation and empty plural translation is stored in msgstr ""', function () {
+            var input = fs.readFileSync(__dirname + '/fixtures/plural.po', 'utf8');
+            var po = PO.parse(input);
+            var str = po.toString();
+            assertHasContiguousLines(str, [
+                'msgid_plural "{{$count}} mistakes"',
+                'msgstr[0] ""'
+            ]);
+        });
     });
 
     describe('C-Strings', function () {


### PR DESCRIPTION
Fixes the same problem as #21 (with tests!).

Before this PR, untranslated plurals were written as follows:
```
msgid "1 destination"
msgid_plural "{{$count}} destinations"
msgstr ""
```

POEdit is unable to open a file containing such plural entries. And gettext utility `msgcat` throws the following error when trying to read the file:
```
zh-CN.po:44:10: syntax error
zh-CN.po:49:10: syntax error
zh-CN.po:54:10: syntax error
zh-CN.po:6337:10: syntax error
msgcat: found 4 fatal errors
```

My change will generate this result:
```
msgid "1 destination"
msgid_plural "{{$count}} destinations"
msgstr[0] ""
```

The [gettext docs](https://www.gnu.org/software/gettext/manual/html_node/PO-Files.html#index-plural-forms_002c-in-PO-files) aren't totally clear on this point, but that does appear to be the correct syntax. And neither `msgcat` nor POEdit throw any errors when reading that kind of plural entry.

----

This PR has a couple other mostly-unrelated changes. (Sorry! I normally hate that.)

* I upgraded all `devDependencies` because I couldn't even `npm install` with the previous ones
  * `grunt-jscs-checker` was renamed to `grunt-jscs`
  * `alias` option in `grunt-browserify` doesn't seem necessary anymore? Browserify v3 was 3+ years ago now!
* I removed `lodash.isarray` in favor of the native `Array.isArray`. There was already code depending on `Object.keys` and `Array.prototype.filter` (https://github.com/rubenv/pofile/blob/v1.0.2/lib/po.js#L309), which are also ES5-only, so I didn't see any reason to _not_ use `Array.isArray`.

I would be happy to remove any of those changes if you want a cleaner PR. Just let me know!