### PR TITLE
Stub out missing translations according to language plurals

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -114,7 +114,9 @@ PO.parse = function (data) {
         }
     });
 
-    var item = new PO.Item();
+    var parsedPluralForms = PO.parsePluralForms(po.headers['Plural-Forms']);
+    var nplurals = parsedPluralForms.nplurals;
+    var item = new PO.Item({ nplurals: nplurals });
     var context = null;
     var plural = 0;
     var obsoleteCount = 0;
@@ -128,7 +130,7 @@ PO.parse = function (data) {
             obsoleteCount = 0;
             noCommentLineCount = 0;
             po.items.push(item);
-            item = new PO.Item();
+            item = new PO.Item({ nplurals: nplurals });
         }
     }
 
@@ -234,7 +236,26 @@ PO.parse = function (data) {
     return po;
 };
 
-PO.Item = function () {
+PO.parsePluralForms = function (pluralFormsString) {
+    var results = (pluralFormsString || '')
+        .split(';')
+        .reduce(function (acc, keyValueString) {
+            var trimmedString = keyValueString.trim();
+            var equalsIndex = trimmedString.indexOf('=');
+            var key = trimmedString.substring(0, equalsIndex).trim();
+            var value = trimmedString.substring(equalsIndex + 1).trim();
+            acc[key] = value;
+            return acc;
+        }, {});
+    return {
+        nplurals: results.nplurals,
+        plural: results.plural
+    };
+};
+
+PO.Item = function (options) {
+    var nplurals = options && options.nplurals;
+
     this.msgid = '';
     this.msgctxt = null;
     this.references = [];
@@ -244,6 +265,8 @@ PO.Item = function () {
     this.extractedComments = [];
     this.flags = {};
     this.obsolete = false;
+    var npluralsNumber = Number(nplurals);
+    this.nplurals = (isNaN(npluralsNumber)) ? 2 : npluralsNumber;
 };
 
 PO.Item.prototype.toString = function () {
@@ -316,10 +339,21 @@ PO.Item.prototype.toString = function () {
     ['msgctxt', 'msgid', 'msgid_plural', 'msgstr'].forEach(function (keyword) {
         var text = self[keyword];
         if (text != null) {
+            var hasTranslation = false;
+            if (Array.isArray(text)) {
+                hasTranslation = text.some(function (text) {
+                    return text;
+                });
+            }
+
             if (Array.isArray(text) && text.length > 1) {
                 text.forEach(function (t, i) {
                     lines = lines.concat(mkObsolete + _process(keyword, t, i));
                 });
+            } else if (self.msgid_plural && keyword === 'msgstr' && !hasTranslation) {
+                for (var pluralIndex = 0; pluralIndex < self.nplurals; pluralIndex++) {
+                    lines = lines.concat(mkObsolete + _process(keyword, '', pluralIndex));
+                }
             } else {
                 var index = (self.msgid_plural && Array.isArray(text)) ?
                     0 :

--- a/test/fixtures/plurals/messages.po
+++ b/test/fixtures/plurals/messages.po
@@ -1,0 +1,30 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2017-02-13 09:59-0500\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+# correct plurals
+msgid "1 thing"
+msgid_plural "{{$count}} things"
+msgstr[0] ""
+msgstr[1] ""
+
+# incorrect plurals
+msgid "1 mistake"
+msgid_plural "{{$count}} mistakes"
+msgstr ""

--- a/test/fixtures/plurals/nplurals-1.po
+++ b/test/fixtures/plurals/nplurals-1.po
@@ -1,0 +1,37 @@
+# Chinese translation of Link (6.x-2.9)
+# Copyright (c) 2011 by the Chinese translation team
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Link (6.x-2.9)\n"
+"POT-Creation-Date: 2011-12-31 23:39+0000\n"
+"PO-Revision-Date: 2013-12-17 14:59+0100\n"
+"Language-Team: Chinese\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"Last-Translator: Ruben Vermeersch <ruben@rocketeer.be>\n"
+"Language: zh_CN\n"
+"X-Generator: Poedit 1.6.2\n"
+
+# correct plurals, with translation
+msgid "1 thing"
+msgid_plural "{{$count}} things"
+msgstr[0] "{{$count}} thing"
+
+# correct plurals, with no translation
+msgid "1 other thing"
+msgid_plural "{{$count}} other things"
+msgstr[0] ""
+
+# incorrect plurals, with translation
+msgid "1 mistake"
+msgid_plural "{{$count}} mistakes"
+msgstr[0] "1 mistake"
+msgstr[1] "{{$count}} mistakes"
+
+# incorrect plurals, with no translation
+msgid "1 other mistake"
+msgid_plural "{{$count}} other mistakes"
+msgstr ""

--- a/test/fixtures/plurals/nplurals-2.po
+++ b/test/fixtures/plurals/nplurals-2.po
@@ -1,0 +1,38 @@
+# French translation of Link (6.x-2.9)
+# Copyright (c) 2011 by the French translation team
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Link (6.x-2.9)\n"
+"POT-Creation-Date: 2011-12-31 23:39+0000\n"
+"PO-Revision-Date: 2013-12-17 14:59+0100\n"
+"Language-Team: French\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Last-Translator: Ruben Vermeersch <ruben@rocketeer.be>\n"
+"Language: fr\n"
+"X-Generator: Poedit 1.6.2\n"
+
+# correct plurals, with translation
+msgid "1 thing"
+msgid_plural "{{$count}} things"
+msgstr[0] "1 thing"
+msgstr[1] "{{$count}} things"
+
+# correct plurals, with no translation
+msgid "1 other thing"
+msgid_plural "{{$count}} other things"
+msgstr[0] ""
+msgstr[1] ""
+
+# incorrect plurals, with translation
+msgid "1 mistake"
+msgid_plural "{{$count}} mistakes"
+msgstr[0] "1 mistake"
+
+# incorrect plurals, with no translation
+msgid "1 other mistake"
+msgid_plural "{{$count}} other mistakes"
+msgstr ""

--- a/test/fixtures/plurals/nplurals-3.po
+++ b/test/fixtures/plurals/nplurals-3.po
@@ -1,0 +1,41 @@
+# Polish translation of Link (6.x-2.9)
+# Copyright (c) 2011 by the Polish translation team
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Link (6.x-2.9)\n"
+"POT-Creation-Date: 2011-12-31 23:39+0000\n"
+"PO-Revision-Date: 2013-12-17 14:59+0100\n"
+"Language-Team: Polish\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Last-Translator: Ruben Vermeersch <ruben@rocketeer.be>\n"
+"Language: pl_PL\n"
+"X-Generator: Poedit 1.6.2\n"
+
+# correct plurals, with translation
+msgid "1 thing"
+msgid_plural "{{$count}} things"
+msgstr[0] "1 thing"
+msgstr[1] "{{$count}} things"
+msgstr[2] "{{$count}} things"
+
+# correct plurals, with no translation
+msgid "1 other thing"
+msgid_plural "{{$count}} other things"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+# incorrect plurals, with translation
+msgid "1 mistake"
+msgid_plural "{{$count}} mistakes"
+msgstr[0] "1 mistake"
+msgstr[1] "{{$count}} mistakes"
+
+# incorrect plurals, with no translation
+msgid "1 other mistake"
+msgid_plural "{{$count}} other mistakes"
+msgstr ""

--- a/test/fixtures/plurals/nplurals-6.po
+++ b/test/fixtures/plurals/nplurals-6.po
@@ -1,0 +1,49 @@
+# Arabic translation of Link (6.x-2.9)
+# Copyright (c) 2011 by the Arabic translation team
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Link (6.x-2.9)\n"
+"POT-Creation-Date: 2011-12-31 23:39+0000\n"
+"PO-Revision-Date: 2013-12-17 14:59+0100\n"
+"Language-Team: Arabic\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
+"&& n%100<=10 ? 3 : n%100>=11 && n%100<=99 ? 4 : 5);\n"
+"Last-Translator: Ruben Vermeersch <ruben@rocketeer.be>\n"
+"Language: ar\n"
+"X-Generator: Poedit 1.6.2\n"
+
+# correct plurals, with translation
+msgid "1 thing"
+msgid_plural "{{$count}} things"
+msgstr[0] "1 thing"
+msgstr[1] "{{$count}} things"
+msgstr[2] "{{$count}} things"
+msgstr[3] "{{$count}} things"
+msgstr[4] "{{$count}} things"
+msgstr[5] "{{$count}} things"
+
+# correct plurals, with no translation
+msgid "1 other thing"
+msgid_plural "{{$count}} other things"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+msgstr[3] ""
+msgstr[4] ""
+msgstr[5] ""
+
+# incorrect plurals, with translation
+msgid "1 mistake"
+msgid_plural "{{$count}} mistakes"
+msgstr[0] "1 mistake"
+msgstr[1] "{{$count}} mistakes"
+msgstr[2] "{{$count}} mistakes"
+
+# incorrect plurals, with no translation
+msgid "1 other mistake"
+msgid_plural "{{$count}} other mistakes"
+msgstr ""

--- a/test/fixtures/plurals/nplurals-missing.po
+++ b/test/fixtures/plurals/nplurals-missing.po
@@ -1,32 +1,37 @@
-# French translation of Link (6.x-2.9)
-# Copyright (c) 2011 by the French translation team
+# Chinese translation of Link (6.x-2.9)
+# Copyright (c) 2011 by the Chinese translation team
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Link (6.x-2.9)\n"
 "POT-Creation-Date: 2011-12-31 23:39+0000\n"
 "PO-Revision-Date: 2013-12-17 14:59+0100\n"
-"Language-Team: French\n"
+"Language-Team: Chinese\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "Last-Translator: Ruben Vermeersch <ruben@rocketeer.be>\n"
-"Language: fr\n"
+"Language: zh_CN\n"
 "X-Generator: Poedit 1.6.2\n"
 
 # correct plurals, with translation
-msgid "1 source"
-msgid_plural "{{$count}} sources"
-msgstr[0] "1 source"
-msgstr[1] "{{$count}} sources"
+msgid "1 thing"
+msgid_plural "{{$count}} things"
+msgstr[0] "1 thing"
+msgstr[1] "{{$count}} things"
 
 # correct plurals, with no translation
-msgid "1 destination"
-msgid_plural "{{$count}} destinations"
+msgid "1 other thing"
+msgid_plural "{{$count}} other things"
 msgstr[0] ""
+msgstr[1] ""
 
-# incorrect plurals, with no translation
+# incorrect plurals, with translation
 msgid "1 mistake"
 msgid_plural "{{$count}} mistakes"
+msgstr[0] "1 mistake"
+
+# incorrect plurals, with no translation
+msgid "1 other mistake"
+msgid_plural "{{$count}} other mistakes"
 msgstr ""

--- a/test/parse-plural-forms.js
+++ b/test/parse-plural-forms.js
@@ -1,0 +1,52 @@
+var assert = require('assert');
+var fs = require('fs');
+var PO = require('..');
+
+describe('.parsePluralForms()', function () {
+    it('should return an object with empty nplurals and plural expression when there is no plural forms header', function () {
+        var expected = {
+            nplurals: undefined,
+            plural: undefined
+        };
+        assert.deepEqual(PO.parsePluralForms(), expected);
+        assert.deepEqual(PO.parsePluralForms(null), expected);
+        assert.deepEqual(PO.parsePluralForms(''), expected);
+    });
+
+    it('should return an object with nplurals and plural set to xgettext\'s default output', function () {
+        var pluralForms = 'nplurals=INTEGER; plural=EXPRESSION;';
+
+        var expected = {
+            nplurals: 'INTEGER',
+            plural: 'EXPRESSION'
+        };
+        var actual = PO.parsePluralForms(pluralForms);
+        assert.deepEqual(actual, expected);
+    });
+
+    it('should return an object with nplurals and plural set to typical string', function () {
+        var pluralForms = 'nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);';
+
+        var expected = {
+            nplurals: '3',
+            plural: '(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)'
+        };
+        var actual = PO.parsePluralForms(pluralForms);
+        assert.deepEqual(actual, expected);
+    });
+
+    // node-gettext stores plural forms strings with spaces. They don't appear
+    // to write PO files at all, but it seems prudent to handle this case
+    // anyway. See
+    // https://github.com/alexanderwallin/node-gettext/blob/v1.1.0/lib/plurals.js#L14
+    it('should handle spaces around assignments in plural forms string', function () {
+        var pluralForms = 'nplurals = 3; plural = (n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);';
+
+        var expected = {
+            nplurals: '3',
+            plural: '(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2)'
+        };
+        var actual = PO.parsePluralForms(pluralForms);
+        assert.deepEqual(actual, expected);
+    });
+});

--- a/test/write.js
+++ b/test/write.js
@@ -119,34 +119,323 @@ describe('Write', function () {
     });
 
     describe('plurals', function () {
-        it('should write multiple msgstrs', function () {
-            var input = fs.readFileSync(__dirname + '/fixtures/plural.po', 'utf8');
-            var po = PO.parse(input);
-            var str = po.toString();
-            assertHasContiguousLines(str, [
-                'msgstr[0] "1 source"',
-                'msgstr[1] "{{$count}} sources"'
-            ]);
+        describe('nplurals INTEGER', function () {
+            it('should write 2 msgstrs when formatted correctly', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/messages.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} things"',
+                    'msgstr[0] ""',
+                    'msgstr[1] ""'
+                ]);
+            });
+
+            it('should write 2 msgstrs when formatted incorrectly', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/messages.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} mistakes"',
+                    'msgstr[0] ""',
+                    'msgstr[1] ""'
+                ]);
+            });
         });
 
-        it('should write msgstr[0] when there is no translation', function () {
-            var input = fs.readFileSync(__dirname + '/fixtures/plural.po', 'utf8');
-            var po = PO.parse(input);
-            var str = po.toString();
-            assertHasContiguousLines(str, [
-                'msgid_plural "{{$count}} destinations"',
-                'msgstr[0] ""'
-            ]);
+        describe('nplurals missing', function () {
+            it('should write 2 msgstrs when formatted correctly with translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-missing.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} things"',
+                    'msgstr[0] "1 thing"',
+                    'msgstr[1] "{{$count}} things"'
+                ]);
+            });
+
+            it('should write 2 msgstrs when formatted correctly with no translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-missing.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} other things"',
+                    'msgstr[0] ""',
+                    'msgstr[1] ""',
+                ]);
+            });
+
+            it('should keep same number of msgstrs when formatted incorrectly with translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-missing.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} mistakes"',
+                    'msgstr[0] "1 mistake"',
+                    '',
+                    '# incorrect plurals, with no translation'
+                ]);
+            });
+
+            it('should write 2 msgstrs when formatted incorrectly with no translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-missing.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} other mistakes"',
+                    'msgstr[0] ""',
+                    'msgstr[1] ""'
+                ]);
+            });
         });
 
-        it('should write msgstr[0] when there is no translation and empty plural translation is stored in msgstr ""', function () {
-            var input = fs.readFileSync(__dirname + '/fixtures/plural.po', 'utf8');
-            var po = PO.parse(input);
-            var str = po.toString();
-            assertHasContiguousLines(str, [
-                'msgid_plural "{{$count}} mistakes"',
-                'msgstr[0] ""'
-            ]);
+        describe('nplurals=1', function () {
+            it('should write 1 msgstr when formatted correctly with translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-1.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} things"',
+                    'msgstr[0] "{{$count}} thing"'
+                ]);
+            });
+
+            it('should write 1 msgstr when formatted correctly with no translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-1.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} other things"',
+                    'msgstr[0] ""',
+                    '',
+                    '# incorrect plurals, with translation'
+                ]);
+            });
+
+            it('should keep same number of msgstrs when formatted incorrectly with translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-1.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} mistakes"',
+                    'msgstr[0] "1 mistake"',
+                    'msgstr[1] "{{$count}} mistakes"'
+                ]);
+            });
+
+            it('should write 1 msgstr when formatted incorrectly with no translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-1.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} other mistakes"',
+                    'msgstr[0] ""'
+                ]);
+            });
+        });
+
+        describe('nplurals=2', function () {
+            it('should write 2 msgstrs when formatted correctly with translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-2.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} things"',
+                    'msgstr[0] "1 thing"',
+                    'msgstr[1] "{{$count}} things"'
+                ]);
+            });
+
+            it('should write 2 msgstrs when formatted correctly with no translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-2.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} other things"',
+                    'msgstr[0] ""',
+                    'msgstr[1] ""',
+                ]);
+            });
+
+            it('should keep same number of msgstrs when formatted incorrectly with translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-2.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} mistakes"',
+                    'msgstr[0] "1 mistake"',
+                    '',
+                    '# incorrect plurals, with no translation'
+                ]);
+            });
+
+            it('should write 2 msgstrs when formatted incorrectly with no translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-2.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} other mistakes"',
+                    'msgstr[0] ""',
+                    'msgstr[1] ""'
+                ]);
+            });
+        });
+
+        describe('nplurals=3', function () {
+            it('should write 3 msgstrs when formatted correctly with translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-3.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} things"',
+                    'msgstr[0] "1 thing"',
+                    'msgstr[1] "{{$count}} things"',
+                    'msgstr[2] "{{$count}} things"'
+                ]);
+            });
+
+            it('should write 3 msgstrs when formatted correctly with no translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-3.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} other things"',
+                    'msgstr[0] ""',
+                    'msgstr[1] ""',
+                    'msgstr[2] ""'
+                ]);
+            });
+
+            it('should keep same number of msgstrs when formatted incorrectly with translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-3.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} mistakes"',
+                    'msgstr[0] "1 mistake"',
+                    'msgstr[1] "{{$count}} mistakes"',
+                    '',
+                    '# incorrect plurals, with no translation'
+                ]);
+            });
+
+            it('should write 3 msgstrs when formatted incorrectly with no translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-3.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} other mistakes"',
+                    'msgstr[0] ""',
+                    'msgstr[1] ""',
+                    'msgstr[2] ""'
+                ]);
+            });
+        });
+
+        describe('nplurals=6', function () {
+            it('should write 6 msgstrs when formatted correctly with translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-6.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} things"',
+                    'msgstr[0] "1 thing"',
+                    'msgstr[1] "{{$count}} things"',
+                    'msgstr[2] "{{$count}} things"',
+                    'msgstr[3] "{{$count}} things"',
+                    'msgstr[4] "{{$count}} things"',
+                    'msgstr[5] "{{$count}} things"'
+                ]);
+            });
+
+            it('should write 6 msgstrs when formatted correctly with no translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-6.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} other things"',
+                    'msgstr[0] ""',
+                    'msgstr[1] ""',
+                    'msgstr[2] ""',
+                    'msgstr[3] ""',
+                    'msgstr[4] ""',
+                    'msgstr[5] ""'
+                ]);
+            });
+
+            it('should keep same number of msgstrs when formatted incorrectly with translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-6.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} mistakes"',
+                    'msgstr[0] "1 mistake"',
+                    'msgstr[1] "{{$count}} mistakes"',
+                    'msgstr[2] "{{$count}} mistakes"',
+                    '',
+                    '# incorrect plurals, with no translation'
+                ]);
+            });
+
+            it('should write 6 msgstrs when formatted incorrectly with no translation', function () {
+                var input = fs.readFileSync(
+                    __dirname + '/fixtures/plurals/nplurals-6.po', 'utf8'
+                );
+                var po = PO.parse(input);
+                var str = po.toString();
+                assertHasContiguousLines(str, [
+                    'msgid_plural "{{$count}} other mistakes"',
+                    'msgstr[0] ""',
+                    'msgstr[1] ""',
+                    'msgstr[2] ""',
+                    'msgstr[3] ""',
+                    'msgstr[4] ""',
+                    'msgstr[5] ""'
+                ]);
+            });
         });
     });
 


### PR DESCRIPTION
Enacts the observed `msgmerge` behavior outlined in https://github.com/rubenv/pofile/pull/24#issuecomment-279147804.

I exposed `PO.parsePluralForms` for easy testing, but it seems like it could be useful anyway. Probably not commonly-used enough to add docs though, right?

I'm open to any feedback on this PR as a whole. If it can be cleaner, I'm all for that!