### PR TITLE
Avoid putting a space in empty comments

### DIFF
--- a/lib/po.js
+++ b/lib/po.js
@@ -20,12 +20,12 @@ PO.prototype.toString = function () {
 
     if (this.comments) {
         this.comments.forEach(function (comment) {
-            lines.push('# ' + comment);
+            lines.push(('# ' + comment).trim());
         });
     }
     if (this.extractedComments) {
         this.extractedComments.forEach(function (comment) {
-            lines.push('#. ' + comment);
+            lines.push(('#. ' + comment).trim());
         });
     }
 

--- a/test/write.js
+++ b/test/write.js
@@ -2,12 +2,13 @@ var assert = require('assert');
 var fs = require('fs');
 var PO = require('..');
 
-function assertHasLine(str, line) {
+function assertHasLine(str, line, doNotTrim) {
     var lines = str.split('\n');
     var found = false;
 
     for (var i = 0; i < lines.length; i++) {
-        if (lines[i].trim() === line) {
+        var lineToCompare = doNotTrim ? lines[i] : lines[i].trim();
+        if (lineToCompare === line) {
             found = true;
             break;
         }
@@ -51,6 +52,13 @@ describe('Write', function () {
         var po = PO.parse(input);
         var str = po.toString();
         assertHasLine(str, '#, fuzzy');
+    });
+
+    it('write empty comment without an unecessary space', function () {
+        var input = fs.readFileSync(__dirname + '/fixtures/fuzzy.po', 'utf8');
+        var po = PO.parse(input);
+        var str = po.toString();
+        assertHasLine(str, '#', true);
     });
 
     it('write flags only when true', function () {


### PR DESCRIPTION
In our pipeline, empty comments in po files are generated without a space after '#' and saving a po file using pofile lib generates unwanted diff that need to be handle manually which is really annoying. This pull request simply test if comment is empty, if so, do not add space after the '#' symbol.