### PR TITLE
Fix type of PO.Item

### DIFF
--- a/pofile.d.ts
+++ b/pofile.d.ts
@@ -36,7 +36,7 @@ declare class PO {
     public static parse(data: string): PO;
     public static parsePluralForms(forms: string): PO;
     public static load(fileName: string, callback: (err: NodeJS.ErrnoException, po: PO) => void): void;
-    public static Item: typeof Item;
+    public static Item: Item;
 
     public save(fileName: string, callback: (err: NodeJS.ErrnoException) => void): void;
     public toString(): string;


### PR DESCRIPTION
Currently, it's not possible to access `Item` type. The proposed change should fix the issue. 

```ts
declare class Item {
    public msgid: string;
    public msgctxt?: string;
    public references: string[];
    public msgid_plural?: string;
    public msgstr: string[];
    public comments: string[];
    public extractedComments: string[];
    public flags: Record<string, boolean | undefined>;
    private nplurals: number;
    private obsolete: boolean;

    public toString(): string;
}

// This is how it's done currently
declare class CurrentPO { 
    public static Item: typeof Item; 
}

// Any of those give warnings or provide a wrong type
declare const currentItem1: CurrentPO.Item
declare const currentItem2: typeof CurrentPO.Item
currentItem2.msgid
declare const currentItem3: InstanceType<CurrentPO.Item>

// This way it will be possible to get Item type without any ts warnings
declare class UpdatedPO { 
    public static Item: Item; 
}

// Works
declare const updatedItem: typeof UpdatedPO.Item
updatedItem.msgid
```

[ts playground](https://www.typescriptlang.org/play/?ssl=33&ssc=18&pln=1&pc=1#code/CYUwxgNghgTiAEkoGdnwJIBcQFt4G8AoeE+ABwFcAjCASzHh2QHNbgAueZTGWgO2YBuYqUo16jFmEwAPTAH5O3XgOGly1OgzgAzEHD5gQyJT37MA2gF01ozRKatgAfTIQKMKBEVczqkSRiWpLMyqYqljYBGuIMYAD2ODggfJgmvhHWtoH2DCByntIgwADCicmp6crmWdFBEjrQoZwASuDxMMAAPNUCADTwVPHxECBQfPAAPvAUfKA6-MUAfNnkvABuUNjwfG4eXul8FDhU+qtkG1sI8VTIIyDYnEP348J1ufCY8QDKfswAFABKcLmYQAX0IhAA9FD4AAVAAWtDQyPgCPiAHd4LRMAByNDAeJ8BBgDwGTAQACehFASDgiGgqHgJTJKUwAAUAPIEeDvWK+LYSLC4TiYSlkEDxHQYbA4QS8iE08DQekJPjcRCs1LCnAARk4LJg5K5ADodUq6SSiRrSUa2TqAEyi8WS6WG42cs2ywi28mOk2ONgWlVW9WYTV27WygDMnHQYfGRjhLq67rZpp1S0hMPhSLQGKglOx4YxtAgEEGCDI8VQtBoCC+8GYDxluE+Lvgpcw6Io4fGRbSndgfHMyGDsBJjLQAFUyMArsAuTy+cFuIKGDq47L5YRFbSQ4hreGKHOF5v2xKpfBZ-PsIvPebCCfb8UdQGWGwgA)

Related to #36