### PR TITLE
Make obsolete public

### DIFF
--- a/pofile.d.ts
+++ b/pofile.d.ts
@@ -21,8 +21,8 @@ declare class Item {
     public comments: string[];
     public extractedComments: string[];
     public flags: Record<string, boolean | undefined>;
+    public obsolete: boolean;
     private nplurals: number;
-    private obsolete: boolean;
 
     public toString(): string;
 }


### PR DESCRIPTION
Currently, it is impossible in TypeScript to tell if an item is obsolete or not.