### PR TITLE
Add license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "Sander Houttekier"
   ],
   "homepage": "http://github.com/rubenv/pofile",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "http://github.com/rubenv/pofile.git"


### PR DESCRIPTION
Hi,
Having the license in the metadata helps downstream use of the project.
Thanks,
Camille 