### PR TITLE
TypeScript: Add type `null` to `Item` properties

### DIFF
--- a/pofile.d.ts
+++ b/pofile.d.ts
@@ -14,9 +14,9 @@ declare interface IHeaders {
 
 declare class Item {
     public msgid: string;
-    public msgctxt?: string;
+    public msgctxt?: string | null | undefined;
     public references: string[];
-    public msgid_plural?: string;
+    public msgid_plural?: string | null | undefined;
     public msgstr: string[];
     public comments: string[];
     public extractedComments: string[];


### PR DESCRIPTION
As can be verified in source code, the properties `Item#msgctxt` and `Item#msgid_plural` will be initialized to `null` instead of `undefined` (https://github.com/rubenv/pofile/blob/master/lib/po.js#L279-L281). However, type `undefined` should remain to not break any existing code.